### PR TITLE
Removed 'token' from headers

### DIFF
--- a/lib/projects.ts
+++ b/lib/projects.ts
@@ -15,7 +15,7 @@ export async function fetchProjects(): Promise<Array<Project> | null> {
 	const response = await fetch('https://api.github.com/users/nurodev/repos', {
 		headers: {
 			...(process.env.GITHUB_PAT && {
-				authorization: `token ${process.env.GITHUB_PAT}`,
+				authorization: `${process.env.GITHUB_PAT}`,
 			}),
 		},
 	});


### PR DESCRIPTION
The 'token' attribute was restricting the authorization from Github API authentication.
To resolve, I checked the requests made by the app using ThunderClient which went like this:
![image](https://user-images.githubusercontent.com/76242518/181426765-7cc93ef5-34d0-408b-89f4-f00afa17a2d6.png)

Now after removing the attribute, the response is as required.
![image](https://user-images.githubusercontent.com/76242518/181426975-c2a102d8-e565-47cb-b16d-e7e75c843aa1.png)

And hence will now use the Github authentication.